### PR TITLE
Fixes lag caused by collision of debris

### DIFF
--- a/lua/entities/pewpew_core/init.lua
+++ b/lua/entities/pewpew_core/init.lua
@@ -110,7 +110,7 @@ function ENT:RemoveAllProps()
 		for _, ent in pairs( self.Props ) do
 			if IsValid(ent) then
 				constraint.RemoveAll( ent )
-				ent:SetCollisionGroup( COLLISION_GROUP_NONE )
+				ent:SetCollisionGroup( COLLISION_GROUP_DEBRIS_TRIGGER )
 				local phys = ent:GetPhysicsObject()
 				if (phys and phys:IsValid()) then
 					phys:EnableMotion(true)


### PR DESCRIPTION
This changes collision group, when PewPew core is used, from "normal" to "debris" for improved performance.

Debris parts will collide with nothing but world and static stuff, and it will hit triggers. Debris parts can be shot, but doesn't collide.