### PR TITLE
Allow e2 "AllowE2Create" convar to restrict to admin use only

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/pewpewfunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/pewpewfunctions.lua
@@ -395,7 +395,7 @@ local function create(ply, bullet, model, pos, ang, dir, fire, reload)
 	local plyIsAdmin = ply:IsAdmin()
 	local plyIsSuperAdmin = ply:IsSuperAdmin()
 	local allowCreate = pewpew:GetConVar("AllowE2Create")
-	lcoal allowAdminCreate = allowCreate == 2
+	local allowAdminCreate = allowCreate == 2
 	
 	if not allowCreate then return end
 	if allowAdminCreate and not plyIsAdmin then return end

--- a/lua/entities/gmod_wire_expression2/core/custom/pewpewfunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/pewpewfunctions.lua
@@ -389,7 +389,7 @@ end
 
 __e2setcost(20)
 
-pewpew:CreateConVar("AllowE2Create", "bool", true)
+pewpew:CreateConVar("AllowE2Create", "int", true)
 
 local function create(ply, bullet, model, pos, ang, dir, fire, reload)
 	local plyIsAdmin = ply:IsAdmin()

--- a/lua/entities/gmod_wire_expression2/core/custom/pewpewfunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/pewpewfunctions.lua
@@ -391,6 +391,14 @@ __e2setcost(20)
 
 pewpew:CreateConVar("AllowE2Create", "int", true)
 
+local dirMap = {}
+dirMap.up      = 1
+dirMap.down    = 2
+dirMap.right   = 3
+dirMap.left    = 4
+dirMap.forward = 5
+dirMap.back    = 6
+
 local function create(ply, bullet, model, pos, ang, dir, fire, reload)
 	local plyIsAdmin = ply:IsAdmin()
 	local plyIsSuperAdmin = ply:IsSuperAdmin()
@@ -410,14 +418,6 @@ local function create(ply, bullet, model, pos, ang, dir, fire, reload)
 	if not IsValid(ent) then return end
 	ply:AddCount("pewpew", ent)
 	ply:AddCleanup("pewpew", ent)
-
-	local dirMap = {}
-	dirMap.up      = 1
-	dirMap.down    = 2
-	dirMap.right   = 3
-	dirMap.left    = 4
-	dirMap.forward = 5
-	dirMap.back    = 6
 
 	local Dir = dirMap[dir] or dirMap.up
 	

--- a/lua/entities/gmod_wire_expression2/core/custom/pewpewfunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/pewpewfunctions.lua
@@ -419,7 +419,7 @@ local function create(ply, bullet, model, pos, ang, dir, fire, reload)
 	dirMap.forward = 5
 	dirMap.back    = 6
 
-	local Dir = dirMap[dir]
+	local Dir = dirMap[dir] or 1
 	
 	ent:SetModel(model)
 

--- a/lua/entities/gmod_wire_expression2/core/custom/pewpewfunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/pewpewfunctions.lua
@@ -419,7 +419,7 @@ local function create(ply, bullet, model, pos, ang, dir, fire, reload)
 	dirMap.forward = 5
 	dirMap.back    = 6
 
-	local Dir = dirMap[dir] or 1
+	local Dir = dirMap[dir] or dirMap.up
 	
 	ent:SetModel(model)
 

--- a/lua/entities/gmod_wire_expression2/core/custom/pewpewfunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/pewpewfunctions.lua
@@ -392,34 +392,34 @@ __e2setcost(20)
 pewpew:CreateConVar("AllowE2Create", "bool", true)
 
 local function create(ply, bullet, model, pos, ang, dir, fire, reload)
+	local plyIsAdmin = ply:IsAdmin()
+	local plyIsSuperAdmin = ply:IsSuperAdmin
+	local allowCreate = pewpew:GetConVar("AllowE2Create")
+	lcoal allowAdminCreate = allowCreate == 2
 	
-	if not pewpew:GetConVar("AllowE2Create") then return end
+	if not allowCreate then return end
+	if allowAdminCreate and not plyIsAdmin then return end
 	if not ply:CheckLimit("pewpew") then return end
 	if not util.IsValidProp(model) then return end
 	local Bullet = pewpew:GetWeapon(bullet)
 	if not bullet then return end
-	if Bullet.AdminOnly and not ply:IsAdmin() then return end
-	if Bullet.SuperAdminOnly and not ply:IsSuperAdmin() then return end
+	if Bullet.AdminOnly and not plyIsAdmin then return end
+	if Bullet.SuperAdminOnly and not plyIsSuperAdmin then return end
 
 	local ent = ents.Create("pewpew_base_cannon")
 	if not IsValid(ent) then return end
 	ply:AddCount("pewpew", ent)
 	ply:AddCleanup("pewpew", ent)
 
-	local Dir
-	if dir == "up" then
-		Dir = 1
-	elseif dir == "down" then
-		Dir = 2
-	elseif dir == "right" then
-		Dir = 3
-	elseif dir == "left" then
-		Dir = 4
-	elseif dir == "forward" then
-		Dir = 5
-	elseif dir == "back" then
-		Dir = 6
-	end
+	local dirMap = {}
+	dirMap.up      = 1
+	dirMap.down    = 2
+	dirMap.right   = 3
+	dirMap.left    = 4
+	dirMap.forward = 5
+	dirMap.back    = 6
+
+	local Dir = dirMap[dir]
 	
 	ent:SetModel(model)
 

--- a/lua/entities/gmod_wire_expression2/core/custom/pewpewfunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/pewpewfunctions.lua
@@ -393,7 +393,7 @@ pewpew:CreateConVar("AllowE2Create", "bool", true)
 
 local function create(ply, bullet, model, pos, ang, dir, fire, reload)
 	local plyIsAdmin = ply:IsAdmin()
-	local plyIsSuperAdmin = ply:IsSuperAdmin
+	local plyIsSuperAdmin = ply:IsSuperAdmin()
 	local allowCreate = pewpew:GetConVar("AllowE2Create")
 	lcoal allowAdminCreate = allowCreate == 2
 	


### PR DESCRIPTION
Allow the pewpew e2 "AllowE2Create" convar to restrict to admin use only when assigned a value of `2`

This also minorly refactors the `pewCreate` function.

The only other functional change is the defaulting of the direction argument in the case that it's invalid. I've opted to default it to "up" (`1`), but any value here is acceptable (perhaps forward?)

Brief testing shows this to be functional, but you'll of course do your own testing.

Thanks!