### PR TITLE
Fix reload commands for rcon

### DIFF
--- a/lua/pewpew_weaponhandler.lua
+++ b/lua/pewpew_weaponhandler.lua
@@ -9,7 +9,7 @@ function pewpew:LoadWeapons()
 	self:LoadDirectory( "pewpewbullets" )
 end
 concommand.Add("PewPew_LoadBullets",function(ply,cmd,args) 
-	if (ply:IsSuperAdmin() or !ply:IsValid()) then
+	if ( not ply:IsValid() or ply:IsSuperAdmin() ) then
 		pewpew:LoadWeapons()
 	end
 end)
@@ -26,7 +26,7 @@ function pewpew:ReloadWeapons()
 	end
 end
 concommand.Add("PewPew_ReloadWeapons",function(ply,cmd,args)
-	if (ply:IsSuperAdmin() or !ply:IsValid()) then
+	if ( not ply:IsValid() or ply:IsSuperAdmin() ) then
 		pewpew:ReloadWeapons()
 	end
 end)


### PR DESCRIPTION
Currently when using either of the reload commands from rcon, these checks err because, of course `ply` isn't valid when checking `ply:IsSuperAdmin()`

Reversing the checks _should_ fix this issue by short circuiting before checking for `ply:IsSuperAdmin()`

Another option could be `if ply:IsValid() and ply:IsSuperAdmin() or not ply:isValid()` but that reads worse in my opinion.

Credit goes to https://github.com/PLally for making the change on [our fork](https://github.com/CFC-Servers/PewPew), I just thought I'd replicate it over here for ya.

Will update this PR when I confirm that this doesn't break all of the weapons again :p