### PR TITLE
Parity with wiremod/wire#2399

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/pewpewfunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/pewpewfunctions.lua
@@ -293,14 +293,14 @@ __e2setcost(1)
 -- Positions & stuff
 e2function vector pewBulletPos( id )
 	local bullet = getByUniqueID( id )
-	if not bullet then return {0,0,0} end
-	return bullet.Pos or {0,0,0}
+	if not bullet then return Vector(0, 0, 0) end
+	return bullet.Pos or Vector(0, 0, 0)
 end
 
 e2function vector pewBulletVel( id )
 	local bullet = getByUniqueID( id )
-	if not bullet then return {0,0,0} end
-	return bullet.Vel or {0,0,0}
+	if not bullet then return Vector(0, 0, 0) end
+	return bullet.Vel or Vector(0, 0, 0)
 end
 
 e2function entity pewBulletOwner( id )


### PR DESCRIPTION
This PR converts functions that return a table with three numbers to proper Vector/Angle userdata, since that is what vector and angle types will now use in E2 for efficiency.

I'm sweeping through found instances of this on github and making these PRs to make sure the amount of extensions broken by this is minimal.

**Note if this isn't merged, these E2 functions WILL BREAK when wiremod/wire#2399 is merged**